### PR TITLE
46 updating mc heartbeat state to vcu

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -58,7 +58,7 @@ void Error_Handler(void);
 
 /* Private defines -----------------------------------------------------------*/
 #define CAN_TX_TASK_ENABLED 1
-#define MC_HRTBEAT_TASK_ENABLED 1
+#define MC_HRTBEAT_TASK_ENABLED 0
 #define IWDG_RELOAD_PERIOD 4094
 #define BT_DUMP_TASK_ENABLED 0
 #define APPS_PROC_TASK_ENABLED 1
@@ -68,7 +68,7 @@ void Error_Handler(void);
 #define MC_CAN_COMMS_TASK_ENABLED 1
 #define DEFAULT_TASK_ENABLED 0
 #define CAN_RX_TASK_ENABLED 1
-#define WATCH_DOG_TASK_ENABLED 1
+#define WATCH_DOG_TASK_ENABLED 0
 #define ACU_CAN_COMMS_TASK_ENABLED 1
 #define IWDG_EVENT_ALL_ALLOWED_BITS 0xFFFFFF
 #define RTD_LED2_BLUE_Pin GPIO_PIN_2

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -58,7 +58,7 @@ void Error_Handler(void);
 
 /* Private defines -----------------------------------------------------------*/
 #define CAN_TX_TASK_ENABLED 1
-#define MC_HRTBEAT_TASK_ENABLED 0
+#define MC_HRTBEAT_TASK_ENABLED 1
 #define IWDG_RELOAD_PERIOD 4094
 #define BT_DUMP_TASK_ENABLED 0
 #define APPS_PROC_TASK_ENABLED 1
@@ -68,7 +68,7 @@ void Error_Handler(void);
 #define MC_CAN_COMMS_TASK_ENABLED 1
 #define DEFAULT_TASK_ENABLED 0
 #define CAN_RX_TASK_ENABLED 1
-#define WATCH_DOG_TASK_ENABLED 0
+#define WATCH_DOG_TASK_ENABLED 1
 #define ACU_CAN_COMMS_TASK_ENABLED 1
 #define IWDG_EVENT_ALL_ALLOWED_BITS 0xFFFFFF
 #define RTD_LED2_BLUE_Pin GPIO_PIN_2

--- a/Core/Src/vcu_startup.c
+++ b/Core/Src/vcu_startup.c
@@ -33,9 +33,10 @@ bool isButtonPressed(GPIO_TypeDef* port, uint16_t pin);
 #define MC_STARTUP_DELAY_MS 1000	//[ms] delay used to wait for the motor controller
 #define STARTUP_TASK_DELAY_MS 25
 
-#define DISABLE_HEARTBEAT_CHECK 0
+#define DISABLE_HEARTBEAT_CHECK 1
+#define DISABLE_MC_HEARTBEAT 1
 #define DISABLE_SAFETY_LOOP_CHECK 0
-#define DISABLE_BRAKE_CHECK 0
+#define DISABLE_BRAKE_CHECK 1
 #define DISABLE_ACU_ACK 0
 
 void goTsaProcedure(uint8_t *vcuStateTaskNotification) {
@@ -143,7 +144,7 @@ void set_safety_loop_state(enum safetyLoopState state){
 
 int checkHeartbeat() {
 	if(get_acu_heartbeat_state() == HEARTBEAT_PRESENT){
-		if(get_mc_heartbeat_state() == HEARTBEAT_PRESENT) {
+		if((get_mc_heartbeat_state() == HEARTBEAT_PRESENT) || DISABLE_MC_HEARTBEAT) {
 			return true;
 		}
 	}
@@ -227,6 +228,7 @@ static void fail_pulse(){
  * @Return: returns true if the button is pressed, otherwise returns false
  */
 bool isButtonPressed(GPIO_TypeDef* port, uint16_t pin){
+	GPIO_PinState buttonValue = HAL_GPIO_ReadPin(port, pin);
     return (HAL_GPIO_ReadPin(port, pin) == GPIO_PIN_RESET);
 }
 

--- a/Core/Src/vcu_startup.c
+++ b/Core/Src/vcu_startup.c
@@ -33,10 +33,10 @@ bool isButtonPressed(GPIO_TypeDef* port, uint16_t pin);
 #define MC_STARTUP_DELAY_MS 1000	//[ms] delay used to wait for the motor controller
 #define STARTUP_TASK_DELAY_MS 25
 
-#define DISABLE_HEARTBEAT_CHECK 1
-#define DISABLE_MC_HEARTBEAT 1
+#define DISABLE_HEARTBEAT_CHECK 0
+#define DISABLE_MC_HEARTBEAT 0
 #define DISABLE_SAFETY_LOOP_CHECK 0
-#define DISABLE_BRAKE_CHECK 1
+#define DISABLE_BRAKE_CHECK 0
 #define DISABLE_ACU_ACK 0
 
 void goTsaProcedure(uint8_t *vcuStateTaskNotification) {
@@ -228,7 +228,6 @@ static void fail_pulse(){
  * @Return: returns true if the button is pressed, otherwise returns false
  */
 bool isButtonPressed(GPIO_TypeDef* port, uint16_t pin){
-	GPIO_PinState buttonValue = HAL_GPIO_ReadPin(port, pin);
     return (HAL_GPIO_ReadPin(port, pin) == GPIO_PIN_RESET);
 }
 


### PR DESCRIPTION
Added a variable for now to bypass MC heartbeat without disabling the task or changing the initial VCU state to "heartbeat_present". We should definitely revisit all the global variables (and where they are stored). Maybe make a bench_test.h file specifically for mocking/disabling individual pieces of hardware?